### PR TITLE
use warden.session with scope

### DIFF
--- a/lib/devise_security_extension/controllers/helpers.rb
+++ b/lib/devise_security_extension/controllers/helpers.rb
@@ -16,7 +16,7 @@ module DeviseSecurityExtension
         def handle_password_change
           Devise.mappings.keys.flatten.any? do |scope|
             if signed_in? scope
-              if warden.session[:password_expired]
+              if warden.session(scope)[:password_expired]
                 session["#{scope}_return_to"] = request.path if request.get?
                 redirect_for_password_change scope
                 break

--- a/lib/devise_security_extension/hooks/password_expirable.rb
+++ b/lib/devise_security_extension/hooks/password_expirable.rb
@@ -1,3 +1,3 @@
 Warden::Manager.after_authentication do |record, warden, options|
-  warden.session[:password_expired] = record.need_change_password?
+  warden.session(options[:scope])[:password_expired] = record.need_change_password?
 end


### PR DESCRIPTION
it fix problem with defined default scope and trying to logged in as another user with expired password
example:
  you have two scopes admin and user, user is default one
  you logged in as admin
  your password is expired
  but when calling warden.scope without any param you get default scope - user  (it's wrong because you are logged in as admin)
  it raise error ":user user is not logged in"
