### PR TITLE
set protected attributes for OldPassword model

### DIFF
--- a/lib/devise_security_extension/models/old_password.rb
+++ b/lib/devise_security_extension/models/old_password.rb
@@ -1,3 +1,5 @@
 class OldPassword < ActiveRecord::Base
   belongs_to :password_archivable, :polymorphic => true
+
+  attr_accessible :encrypted_password
 end


### PR DESCRIPTION
otherwise there is error ActiveModel::MassAssignmentSecurity::Error (Can't mass-assign protected attributes: encrypted_password

rails 3.2.1, ruby 1.9.3-p0
