### PR TITLE
Check for unique_session_id only if session_limitable is enabled

### DIFF
--- a/lib/devise_security_extension/hooks/session_limitable.rb
+++ b/lib/devise_security_extension/hooks/session_limitable.rb
@@ -17,7 +17,7 @@ Warden::Manager.after_set_user :only => :fetch do |record, warden, options|
   scope = options[:scope]
   env   = warden.request.env
 
-  if warden.authenticated?(scope) && options[:store] != false
+  if record.respond_to?(:unique_session_id) && warden.authenticated?(scope) && options[:store] != false
     if record.unique_session_id != warden.session(scope)['unique_session_id'] && !env['devise.skip_session_limitable']
       warden.logout(scope)
       throw :warden, :scope => scope, :message => :session_limited


### PR DESCRIPTION
I have two models, user and admin, Only user has session_limitable enabled.
When admin tries to login it throws an error:
`NoMethodError (undefined method 'unique_session_id' for #<Admin:0xb437708>):`

This PR fixes it 
