### PR TITLE
Option to avoid the user account expiration by inactivity

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,7 +12,7 @@ An enterprise security extension for devise, trying to meet industrial standard 
 * :secure_validatable - better way to validate a model (email, stronger password validation). Don't use with :validatable!
 * :password_archivable - save used passwords in an old_passwords table for history checks (don't be able to use a formerly used password)
 * :session_limitable - ensures, that there is only one session usable per account at once
-* :expirable - expires a user account after x days of inactivity (default 90 days)
+* :expirable - expires a user account after the defined date and/or x days of inactivity (default 90 days)
 * :security_questionable - as accessible substitution for captchas (security question with captcha fallback)
 
 == Installation
@@ -66,7 +66,10 @@ for :secure_validatable you need to add
 
     # ==> Configuration for :expirable
     # Time period for account expiry from last_activity_at
-    config.expire_after = 90.days
+    # config.expire_after = 90.days
+    #
+    # Set nil if the user doesn't expire by inactivity
+    # config.expire_after = nil
   end
 
 == Captcha-Support

--- a/lib/devise_security_extension/models/expirable.rb
+++ b/lib/devise_security_extension/models/expirable.rb
@@ -2,7 +2,7 @@ require 'devise_security_extension/hooks/expirable'
 
 module Devise
   module Models
-    # Deactivate the account after a configurable amount of time.  To be able to 
+    # Deactivate the account after a configurable amount of time.  To be able to
     # tell, it tracks activity about your account with the following columns:
     #
     # * last_activity_at - A timestamp updated when the user requests a page (only signed in)
@@ -11,10 +11,10 @@ module Devise
     # +:expire_after+ - Time interval to expire accounts after
     #
     # == Additions
-    # Best used with two cron jobs. One for expiring accounts after inactivity, 
-    # and another, that deletes accounts, which have expired for a given amount 
+    # Best used with two cron jobs. One for expiring accounts after inactivity,
+    # and another, that deletes accounts, which have expired for a given amount
     # of time (for example 90 days).
-    # 
+    #
     module Expirable
       extend ActiveSupport::Concern
 
@@ -31,14 +31,16 @@ module Devise
         # expired_at set (manually, via cron, etc.)
         return self.expired_at < Time.now.utc unless self.expired_at.nil?
         # if it is not set, check the last activity against configured expire_after time range
-        return self.last_activity_at < self.class.expire_after.ago unless self.last_activity_at.nil?
-        # if last_activity_at is nil as well, the user has to be 'fresh' and is therefore not expired
+        unless self.class.expire_after.nil? || self.last_activity_at.nil?
+          return self.last_activity_at < self.class.expire_after.ago
+        # if last_activity_at and expired_after are nil as well,
+        # the user has to be 'fresh' and is therefore not expired
         false
       end
 
       # Expire an account. This is for cron jobs and manually expiring of accounts.
       #
-      # @example 
+      # @example
       #   User.expire!
       #   User.expire! 1.week.from_now
       # @note +expired_at+ can be in the future as well
@@ -56,7 +58,7 @@ module Devise
         super && !self.expired?
       end
 
-      # The message sym, if {#active_for_authentication?} returns +false+. E.g. needed 
+      # The message sym, if {#active_for_authentication?} returns +false+. E.g. needed
       # for i18n.
       def inactive_message
         !self.expired? ? super : :expired
@@ -83,17 +85,17 @@ module Devise
           where('expired_at < ?', time.ago)
         end
 
-        # Sample method for daily cron to delete all expired entries after a 
+        # Sample method for daily cron to delete all expired entries after a
         # given amount of +time+.
         #
-        # In your overwritten method you can "blank out" the object instead of 
+        # In your overwritten method you can "blank out" the object instead of
         # deleting it.
         #
         # *Word of warning*: You have to handle the dependent method
-        # on the +resource+ relations (+:destroy+ or +:nullify+) and catch this 
+        # on the +resource+ relations (+:destroy+ or +:nullify+) and catch this
         # behavior (see  http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#label-Deleting+from+associations).
         #
-        # @example 
+        # @example
         #   Resource.delete_all_expired_for 90.days
         # @example You can overide this in your +resource+ model
         #   def self.delete_all_expired_for(time = 90.days)
@@ -109,7 +111,7 @@ module Devise
           expired_for(time).delete_all
         end
 
-        # Version of {#delete_all_expired_for} without arguments (uses 
+        # Version of {#delete_all_expired_for} without arguments (uses
         # configured +delete_expired_after+ default value).
         # @see #delete_all_expired_for
         def delete_all_expired

--- a/lib/generators/devise_security_extension/install_generator.rb
+++ b/lib/generators/devise_security_extension/install_generator.rb
@@ -30,7 +30,9 @@ module DeviseSecurityExtension
         "  # captcha integration for confirmation form\n" +
         "  # config.captcha_for_confirmation = true\n\n" +
         "  # Time period for account expiry from last_activity_at\n" +
-        "  # config.expire_after = 90.days\n\n" +
+        "  # config.expire_after = 90.days\n" +
+        "  # Set nil if the user doesn't expire by inactivity\n" +
+        "  # config.expire_after = nil\n\n" +
         "", :before => /end[ |\n|]+\Z/
       end
 


### PR DESCRIPTION
Hi,

This PR add the option to use the expirable module without considering the users' inactivity days. 

Then, your app can consider that an user is expired only checking the `expired_at` attribute.

To setup this you just need to define `config.expired_after = nil` on the devise initializer.

ps: i didn't find any tests in the gem codebase, so i didn't do one for this patch
