### PR TITLE
Strong Parameters Compatibility

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -11,7 +11,7 @@ class Devise::PasswordExpiredController < DeviseController
   end
 
   def update
-    if resource.update_with_password(params[resource_name])
+    if resource.update_with_password(resource_params)
       warden.session(scope)[:password_expired] = false
       set_flash_message :notice, :updated
       sign_in scope, resource, :bypass => true


### PR DESCRIPTION
When used together with strong parameters it's necessary to call a method to permit params instead of taking params directly from hash: Devise calls resource_params
