### PR TITLE
Return the user to the full path they requested

### DIFF
--- a/lib/devise_security_extension/controllers/helpers.rb
+++ b/lib/devise_security_extension/controllers/helpers.rb
@@ -29,7 +29,7 @@ module DeviseSecurityExtension
           if not devise_controller? and not ignore_password_expire? and not request.format.nil? and request.format.html?
             Devise.mappings.keys.flatten.any? do |scope|
               if signed_in?(scope) and warden.session(scope)[:password_expired]
-                session["#{scope}_return_to"] = request.path if request.get?
+                session["#{scope}_return_to"] = request.fullpath if request.get?
                 redirect_for_password_change scope
                 return
               end


### PR DESCRIPTION
"path" will only include the path, whereas "fullpath" includes any querystring, which is a semantic part of the URL.

This emulates the behaviour of Devise in FailureApp, which uses Warden's "attempted_path", which Warden sets to "fullpath".

As an example, this broke an OAuth interaction which needed querystring parameters passed in the initial GET request.