### PR TITLE
Fixed: Calling permit! on a hash yields a NoMethodError

### DIFF
--- a/lib/devise_security_extension/models/password_archivable.rb
+++ b/lib/devise_security_extension/models/password_archivable.rb
@@ -62,7 +62,7 @@ module Devise
         salt_change = if self.respond_to?(:password_salt_change) and not self.password_salt_change.nil?
           self.password_salt_change.first
         end
-        { :encrypted_password => self.encrypted_password_change.first, :password_salt => salt_change }.permit!
+        { :encrypted_password => self.encrypted_password_change.first, :password_salt => salt_change }
       end
 
       module ClassMethods


### PR DESCRIPTION
This makes sense since permit! is a function of params and not of a generic hash
