### PR TITLE
Avoid saving unvalidated fields

### DIFF
--- a/lib/devise_security_extension/models/expirable.rb
+++ b/lib/devise_security_extension/models/expirable.rb
@@ -20,7 +20,7 @@ module Devise
 
       # Updates +last_activity_at+, called from a Warden::Manager.after_set_user hook.
       def update_last_activity!
-        self.update_column(:last_activity_at, Time.now.utc)
+        update_column :last_activity_at, Time.now.utc
       end
 
       # Tells if the account has expired
@@ -42,8 +42,7 @@ module Devise
       #   User.expire! 1.week.from_now
       # @note +expired_at+ can be in the future as well
       def expire!(at = Time.now.utc)
-        self.expired_at = at
-        save(:validate => false)
+        update_column :expired_at, at
       end
 
       # Overwrites active_for_authentication? from Devise::Models::Activatable

--- a/lib/devise_security_extension/models/password_expirable.rb
+++ b/lib/devise_security_extension/models/password_expirable.rb
@@ -22,22 +22,18 @@ module Devise
 
       # set a fake datetime so a password change is needed and save the record
       def need_change_password!
-        if self.class.expire_password_after.is_a? Fixnum or self.class.expire_password_after.is_a? Float
-          need_change_password
-          self.save(:validate => false)
+        if self.class.expire_password_after.is_a?(Numeric)
+          update_column :password_changed_at, self.class.expire_password_after.ago
         end
+        password_changed_at
       end
 
       # set a fake datetime so a password change is needed
       def need_change_password
-        if self.class.expire_password_after.is_a? Fixnum or self.class.expire_password_after.is_a? Float
-          self.password_changed_at = self.class.expire_password_after.ago
+        if self.class.expire_password_after.is_a?(Numeric)
+          password_changed_at = self.class.expire_password_after.ago
         end
-
-        # is date not set it will set default to need set new password next login
-        need_change_password if self.password_changed_at.nil?
-
-        self.password_changed_at
+        password_changed_at
       end
 
       private

--- a/lib/devise_security_extension/models/session_limitable.rb
+++ b/lib/devise_security_extension/models/session_limitable.rb
@@ -11,9 +11,7 @@ module Devise
       extend ActiveSupport::Concern
 
       def update_unique_session_id!(unique_session_id)
-        self.unique_session_id = unique_session_id
-
-        save(:validate => false)
+        update_column :unique_session_id, unique_session_id
       end
 
     end


### PR DESCRIPTION
If there are any assigned attributes that are invalid, they should not be saved without validation.

This change saves only the DeviseSecurityExtension fields to prevent things like this:

``` ruby
user.assign_attributes(email: "") # bad input
user.need_change_password! # would save whole model, bad input without validation
```

Also it looks like there was a recursive loop inside `need_change_password` which I removed: please check if this is correct unless I missed what that was supposed to do.
