### PR TITLE
Fix warden's session key from symbol to key to work in latest rails

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -12,7 +12,7 @@ class Devise::PasswordExpiredController < DeviseController
 
   def update
     if resource.update_with_password(resource_params)
-      warden.session(scope)[:password_expired] = false
+      warden.session(scope)['password_expired'] = false
       set_flash_message :notice, :updated
       sign_in scope, resource, :bypass => true
       redirect_to stored_location_for(scope) || :root


### PR DESCRIPTION
Like what @jheth mentioned here https://github.com/phatworx/devise_security_extension/pull/88#issuecomment-46627633

I realized it doesn't work in latest rails, so we need to change another place here. If not, it will redirect loop.
