### PR TITLE
Avoid infinite redirect loop after expirable time change

### DIFF
--- a/lib/devise_security_extension/controllers/helpers.rb
+++ b/lib/devise_security_extension/controllers/helpers.rb
@@ -29,9 +29,14 @@ module DeviseSecurityExtension
           if not devise_controller? and not ignore_password_expire? and not request.format.nil? and request.format.html?
             Devise.mappings.keys.flatten.any? do |scope|
               if signed_in?(scope) and warden.session(scope)[:password_expired]
-                session["#{scope}_return_to"] = request.path if request.get?
-                redirect_for_password_change scope
-                return
+                # re-check to avoid infinite loop if date changed after login attempt
+                if send(:"current_#{scope}").try(:need_change_password?)
+                  session["#{scope}_return_to"] = request.path if request.get?
+                  redirect_for_password_change scope
+                  return
+                else
+                  warden.session(scope)[:password_expired] = false
+                end
               end
             end
           end


### PR DESCRIPTION
This will re-check need_change_password? to avoid redirect loop if the date is changed after the warden session variable is set and before the password is changed.