### PR TITLE
Ensure there is always a resource

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -11,6 +11,8 @@ class Devise::PasswordExpiredController < DeviseController
   end
 
   def update
+    redirect_to :root if not resource.nil? and resource.need_change_password?
+
     if resource.update_with_password(resource_params)
       warden.session(scope)[:password_expired] = false
       set_flash_message :notice, :updated


### PR DESCRIPTION
Resource will be nil in the case of a an expired session. This fix will
redirect to the root_path if resource is nil, just like it'll with the
new action.