### PR TITLE
Fixed Redirect loop after successfully changing an expired password

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -12,7 +12,7 @@ class Devise::PasswordExpiredController < DeviseController
 
   def update
     if resource.update_with_password(resource_params)
-      warden.session(scope)[:password_expired] = false
+      warden.session(scope)['password_expired'] = false
       set_flash_message :notice, :updated
       sign_in scope, resource, :bypass => true
       redirect_to stored_location_for(scope) || :root


### PR DESCRIPTION
per Issue #101 

After successfully changing a password for because it was expired, a redirect loop happens because the warden session does not get updated correctly. In `/app/controllers/devise/password_expired_controller.rb` the warden session variable `warden.session(scope)['password_expired']` is set to true. When the password is successfully updated, the warden session variable `warden.session(scope)[:password_expired]` is set to false - setting with the key as symbol :password_expired instead of the convention of the string 'password_expired'.

I've forked and committed the fix, will submit a pull request