### PR TITLE
protect attributes upon expired password update

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -24,7 +24,7 @@ class Devise::PasswordExpiredController < DeviseController
 
   private
     def resource_params
-      params.require(resource_name).permit!
+      params.require(resource_name).permit(:current_password, :password, :password_confirmation)
     end
 
   def scope


### PR DESCRIPTION
You guys gave me a little heartattack with this

```ruby
resource_params = ActionController::Parameters.new({user: {admin: true, password: 'Password1!', password_confirmation: 'Password1!'}}).require('user').permit!
# => {"admin"=>false, "current_password"=>"foobar", "password"=>"Password1!", "password_confirmation"=>"Password1!"}
```

the `resource_params` is passed to Devise `resource.update_with_password(resource_params)` which directly calls rails `update_attributes(params, *options)`

https://github.com/plataformatec/devise/blob/65700b22bab0746a40358dacb32197280acf2888/lib/devise/models/database_authenticatable.rb  

`Devise::Models::DatabaseAuthenticatable#update_with_password`

...and voilà, user updating expired password is now admin in (Rails 4)


my code will strict params passed to only `current_password`, `password`, `password_confirmation`