### PR TITLE
Fix incorrect argument for update_with_password

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -12,7 +12,7 @@ class Devise::PasswordExpiredController < DeviseController
 
   def update
     resource.extend(Devise::Models::DatabaseAuthenticatablePatch)
-    if resource.update_with_password(params[resource_name])
+    if resource.update_with_password(resource_params)
       warden.session(scope)['password_expired'] = false
       set_flash_message :notice, :updated
       sign_in scope, resource, :bypass => true


### PR DESCRIPTION
By adding the `resource.extend` line in version 0.9.0, this caused a bug in the `update` method that resulted in `ActiveModel::ForbiddenAttributesError` when trying to update the password.

The solution is to pass in `resource_params` as an argument instead of `params[resource_name]`.

Needs tests here, but I tested it in my app and this fixed the issue.