### PR TITLE
PasswordArchivable: removed obsolete :passoword_salt from OldPassword.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ add_index :the_resources, :password_changed_at
 ```ruby
 create_table :old_passwords do |t|
   t.string :encrypted_password, :null => false
-  t.string :password_salt
   t.string :password_archivable_type, :null => false
   t.integer :password_archivable_id, :null => false
   t.datetime :created_at

--- a/lib/devise_security_extension/models/password_archivable.rb
+++ b/lib/devise_security_extension/models/password_archivable.rb
@@ -31,14 +31,13 @@ module Devise
           old_passwords_including_cur_change.each do |old_password|
             dummy                    = self.class.new
             dummy.encrypted_password = old_password.encrypted_password
-            dummy.password_salt      = old_password.password_salt if dummy.respond_to?(:password_salt)
             return true if dummy.valid_password?(self.password)
           end
         end
 
         false
       end
-      
+
       def password_changed_to_same?
         pass_change = encrypted_password_change
         pass_change && pass_change.first == pass_change.last
@@ -61,12 +60,9 @@ module Devise
           end
         end
       end
-      
+
       def old_password_params
-        salt_change = if self.respond_to?(:password_salt_change) and not self.password_salt_change.nil?
-          self.password_salt_change.first
-        end
-        { :encrypted_password => self.encrypted_password_change.first, :password_salt => salt_change }
+        { encrypted_password: self.encrypted_password_change.first }
       end
 
       module ClassMethods

--- a/test/dummy/db/migrate/20120508165529_create_tables.rb
+++ b/test/dummy/db/migrate/20120508165529_create_tables.rb
@@ -14,7 +14,6 @@ class CreateTables < ActiveRecord::Migration
 
     create_table :old_passwords do |t|
       t.string :encrypted_password
-      t.string :password_salt
 
       t.references :password_archivable, polymorphic: true
     end


### PR DESCRIPTION
I removed obsolete :password_salt from OldPassword used by PasswordArchivable module.

Devise since version 1.2.1 does not require a password_salt column anymore. The new version of devise uses characters 0 to 29 of the encrypted password field as the salt and the remaining characters in that database field for the encrypted password.