### PR TITLE
Use devise method to store request location

### DIFF
--- a/lib/devise_security_extension/controllers/helpers.rb
+++ b/lib/devise_security_extension/controllers/helpers.rb
@@ -34,7 +34,7 @@ module DeviseSecurityExtension
               if signed_in?(scope) and warden.session(scope)['password_expired']
                 # re-check to avoid infinite loop if date changed after login attempt
                 if send(:"current_#{scope}").try(:need_change_password?)
-                  session["#{scope}_return_to"] = request.original_fullpath if request.get?
+                  store_location_for(scope, request.original_fullpath) if request.get?
                   redirect_for_password_change scope
                   return
                 else
@@ -52,7 +52,7 @@ module DeviseSecurityExtension
           if !devise_controller? && !request.format.nil? && request.format.html?
             Devise.mappings.keys.flatten.any? do |scope|
               if signed_in?(scope) && warden.session(scope)['paranoid_verify']
-                session["#{scope}_return_to"] = request.original_fullpath if request.get?
+                store_location_for(scope, request.original_fullpath) if request.get?
                 redirect_for_paranoid_verification scope
                 return
               end


### PR DESCRIPTION
Currently, redirecting after sign in loses query parameters. This change uses the Devise built-in method to store the location instead of doing it manually (since the Devise method handles query params). This method was created in Devise v.3.2.1, which would change the dependencies for the project.

An example of the problem is OAuth and expired passwords. OAuth makes use of a variety of query parameters to do its business. If the user has an expired password upon login, after successfully updating their password they cannot continue with the login process as all of OAuth's parameters are lost.