### PR TITLE
Fix for Recaptcha Gem Integration. No Need for RMagick 

### DIFF
--- a/lib/devise_security_extension/patches/confirmations_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/confirmations_controller_captcha.rb
@@ -3,9 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 
           if successfully_sent?(resource)

--- a/lib/devise_security_extension/patches/confirmations_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/confirmations_controller_security_question.rb
@@ -6,9 +6,7 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha])) or
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) or
            (resource.security_question_answer.present? and resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 

--- a/lib/devise_security_extension/patches/passwords_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/passwords_controller_captcha.rb
@@ -3,9 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise_security_extension/patches/passwords_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/passwords_controller_security_question.rb
@@ -6,9 +6,7 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
            (resource.security_question_answer.present? and resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)

--- a/lib/devise_security_extension/patches/registrations_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/registrations_controller_captcha.rb
@@ -5,10 +5,7 @@ module DeviseSecurityExtension::Patches
       define_method :create do |&block|
         build_resource(sign_up_params)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
-
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           if resource.save
             block.call(resource) if block
             if resource.active_for_authentication?

--- a/lib/devise_security_extension/patches/sessions_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/sessions_controller_captcha.rb
@@ -3,9 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do |&block|
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = warden.authenticate!(auth_options)
           set_flash_message(:notice, :signed_in) if is_flashing_format?
           sign_in(resource_name, resource)

--- a/lib/devise_security_extension/patches/unlocks_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/unlocks_controller_captcha.rb
@@ -3,9 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise_security_extension/patches/unlocks_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/unlocks_controller_security_question.rb
@@ -6,9 +6,7 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha
-        params[:captcha])) or ((defined? valid_captcha?) && (valid_captcha?
-        params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
            (resource.security_question_answer.present? and resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)


### PR DESCRIPTION
Fixed verify_recaptcha check. Gem recaptcha does not set params[:captcha] nor does in need to have recaptcha passed in as an argument.