### PR TITLE
Fix mistake in default regex of initializer

### DIFF
--- a/lib/generators/templates/devise_security_extension.rb
+++ b/lib/generators/templates/devise_security_extension.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # config.expire_password_after = false
 
   # Need 1 char of A-Z, a-z and 0-9
-  # config.password_regex = /(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])/
+  # config.password_regex = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z])/
 
   # How many passwords to keep in archive
   # config.password_archiving_count = 5


### PR DESCRIPTION
The default regex in the initializer has a mistake. It is literally matching `\d` rather than any digit [0-9]