### PR TITLE
Remove `assert_template` test 

### DIFF
--- a/test/test_password_expired_controller.rb
+++ b/test/test_password_expired_controller.rb
@@ -13,7 +13,7 @@ class Devise::PasswordExpiredControllerTest < ActionController::TestCase
 
   test 'should render show' do
     get :show
-    assert_template :show
+    assert_includes @response.body, 'Renew your password'
   end
 
   test 'shold update password' do


### PR DESCRIPTION
These tests are not included in rails anymore and require a gem. I changed the test to match of the page body contents but I'm not sure if that is the right move. It is a more fragile test. I'm open to suggestions.