### PR TITLE
Take into an account custom Devise.router_name

### DIFF
--- a/lib/devise_security_extension/controllers/helpers.rb
+++ b/lib/devise_security_extension/controllers/helpers.rb
@@ -73,13 +73,17 @@ module DeviseSecurityExtension
         def change_password_required_path_for(resource_or_scope = nil)
           scope       = Devise::Mapping.find_scope!(resource_or_scope)
           change_path = "#{scope}_password_expired_path"
-          send(change_path)
+          _devise_security_extention_route_context.send(change_path)
         end
 
         def paranoid_verification_code_path_for(resource_or_scope = nil)
           scope       = Devise::Mapping.find_scope!(resource_or_scope)
           change_path = "#{scope}_paranoid_verification_code_path"
-          send(change_path)
+          _devise_security_extention_route_context.send(change_path)
+        end
+
+        def _devise_security_extention_route_context
+          @_devise_security_extention_route_context ||= send(Devise.available_router_name)
         end
 
         protected


### PR DESCRIPTION
I've put my Devise inside an Rails Engine and set custom `router_name`.  As a result url helpers where not found inside main application which mounted this engine. Undefined method `password_expired_path` had been invoked, but my helper was `my_engine.password_expired_path`.
Here is a small fix for this.