### PR TITLE
Replace low-priority operators

### DIFF
--- a/lib/devise_security_extension/controllers/helpers.rb
+++ b/lib/devise_security_extension/controllers/helpers.rb
@@ -29,9 +29,9 @@ module DeviseSecurityExtension
         def handle_password_change
           return if warden.nil?
 
-          if not devise_controller? and not ignore_password_expire? and not request.format.nil? and request.format.html?
+          if !devise_controller? && !ignore_password_expire? && !request.format.nil? && request.format.html?
             Devise.mappings.keys.flatten.any? do |scope|
-              if signed_in?(scope) and warden.session(scope)['password_expired']
+              if signed_in?(scope) && warden.session(scope)['password_expired']
                 # re-check to avoid infinite loop if date changed after login attempt
                 if send(:"current_#{scope}").try(:need_change_password?)
                   store_location_for(scope, request.original_fullpath) if request.get?

--- a/lib/devise_security_extension/models/password_archivable.rb
+++ b/lib/devise_security_extension/models/password_archivable.rb
@@ -11,20 +11,20 @@ module Devise
       end
 
       def validate_password_archive
-        errors.add(:password, :taken_in_past) if encrypted_password_changed? and password_archive_included?
+        errors.add(:password, :taken_in_past) if encrypted_password_changed? && password_archive_included?
       end
 
       # validate is the password used in the past
       def password_archive_included?
         unless deny_old_passwords.is_a? Fixnum
-          if deny_old_passwords.is_a? TrueClass and archive_count > 0
+          if deny_old_passwords.is_a?(TrueClass) && archive_count > 0
             self.deny_old_passwords = archive_count
           else
             self.deny_old_passwords = 0
           end
         end
 
-        if self.class.deny_old_passwords > 0 and not self.password.nil?
+        if self.class.deny_old_passwords > 0 && !self.password.nil?
           old_passwords_including_cur_change = self.old_passwords.order(:id).reverse_order.limit(self.class.deny_old_passwords).to_a
           old_passwords_including_cur_change << OldPassword.new(old_password_params)  # include most recent change in list, but don't save it yet!
           old_passwords_including_cur_change.each do |old_password|

--- a/lib/devise_security_extension/models/password_expirable.rb
+++ b/lib/devise_security_extension/models/password_expirable.rb
@@ -13,8 +13,8 @@ module Devise
 
       # is an password change required?
       def need_change_password?
-        if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
-          self.password_changed_at.nil? or self.password_changed_at < self.expire_password_after.seconds.ago
+        if self.expire_password_after.is_a?(Fixnum) || self.expire_password_after.is_a?(Float)
+          self.password_changed_at.nil? || self.password_changed_at < self.expire_password_after.seconds.ago
         else
           false
         end
@@ -22,7 +22,7 @@ module Devise
 
       # set a fake datetime so a password change is needed and save the record
       def need_change_password!
-        if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
+        if self.expire_password_after.is_a?(Fixnum) || self.expire_password_after.is_a?(Float)
           need_change_password
           self.save(:validate => false)
         end
@@ -30,7 +30,7 @@ module Devise
 
       # set a fake datetime so a password change is needed
       def need_change_password
-        if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
+        if self.expire_password_after.is_a?(Fixnum) || self.expire_password_after.is_a?(Float)
           self.password_changed_at = self.expire_password_after.seconds.ago
         end
 
@@ -39,7 +39,7 @@ module Devise
 
         self.password_changed_at
       end
-      
+
       def expire_password_after
         self.class.expire_password_after
       end
@@ -48,7 +48,7 @@ module Devise
 
         # is password changed then update password_cahanged_at
         def update_password_changed
-          self.password_changed_at = Time.now if (self.new_record? or self.encrypted_password_changed?) and not self.password_changed_at_changed?
+          self.password_changed_at = Time.now if (self.new_record? || self.encrypted_password_changed?) && !self.password_changed_at_changed?
         end
 
       module ClassMethods

--- a/lib/devise_security_extension/models/secure_validatable.rb
+++ b/lib/devise_security_extension/models/secure_validatable.rb
@@ -55,10 +55,10 @@ module Devise
       end
 
       def current_equal_password_validation
-        if not self.new_record? and not self.encrypted_password_change.nil?
+        if not self.new_record? && !self.encrypted_password_change.nil?
           dummy = self.class.new
           dummy.encrypted_password = self.encrypted_password_change.first
-          dummy.password_salt = self.password_salt_change.first if self.respond_to? :password_salt_change and not self.password_salt_change.nil?
+          dummy.password_salt = self.password_salt_change.first if self.respond_to? :password_salt_change && !self.password_salt_change.nil?
           self.errors.add(:password, :equal_to_current_password) if dummy.valid_password?(self.password)
         end
       end

--- a/lib/devise_security_extension/patches/confirmations_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/confirmations_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 
           if successfully_sent?(resource)

--- a/lib/devise_security_extension/patches/confirmations_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/confirmations_controller_security_question.rb
@@ -6,8 +6,8 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) or
-           (resource.security_question_answer.present? and resource.security_question_answer == params[:security_question_answer])
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) ||
+           (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 
           if successfully_sent?(resource)

--- a/lib/devise_security_extension/patches/passwords_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/passwords_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise_security_extension/patches/passwords_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/passwords_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) ||
            (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)

--- a/lib/devise_security_extension/patches/passwords_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/passwords_controller_security_question.rb
@@ -6,8 +6,8 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
-           (resource.security_question_answer.present? and resource.security_question_answer == params[:security_question_answer])
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+           (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise_security_extension/patches/registrations_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/registrations_controller_captcha.rb
@@ -5,7 +5,7 @@ module DeviseSecurityExtension::Patches
       define_method :create do |&block|
         build_resource(sign_up_params)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           if resource.save
             block.call(resource) if block
             if resource.active_for_authentication?
@@ -21,7 +21,7 @@ module DeviseSecurityExtension::Patches
             clean_up_passwords resource
             respond_with resource
           end
-          
+
         else
           resource.errors.add :base, t('devise.invalid_captcha')
           clean_up_passwords resource

--- a/lib/devise_security_extension/patches/sessions_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/sessions_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do |&block|
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = warden.authenticate!(auth_options)
           set_flash_message(:notice, :signed_in) if is_flashing_format?
           sign_in(resource_name, resource)
@@ -14,7 +14,7 @@ module DeviseSecurityExtension::Patches
           respond_with({}, :location => new_session_path(resource_name))
         end
       end
-    
+
       # for bad protected use in controller
       define_method :auth_options do
         { :scope => resource_name, :recall => "#{controller_path}#new" }

--- a/lib/devise_security_extension/patches/unlocks_controller_captcha.rb
+++ b/lib/devise_security_extension/patches/unlocks_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurityExtension::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise_security_extension/patches/unlocks_controller_security_question.rb
+++ b/lib/devise_security_extension/patches/unlocks_controller_security_question.rb
@@ -6,8 +6,8 @@ module DeviseSecurityExtension::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) or ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
-           (resource.security_question_answer.present? and resource.security_question_answer == params[:security_question_answer])
+        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) ||
+           (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))


### PR DESCRIPTION
The operator inconsistencies have always bugged me. High-priority (`&&`, `||`, `!`) and low-priority (`and`, `or`, `not`) operators are used interchangably throughout the code, and it's caused bugs in the past. This is an attempt to standardize them to the high-priority operators so there's less chance of future mishaps.

I also found a couple of operators which were missing altogether, so I added those in.