### PR TITLE
Don't change Devise config from a model instance

### DIFF
--- a/lib/devise_security_extension/models/password_archivable.rb
+++ b/lib/devise_security_extension/models/password_archivable.rb
@@ -16,16 +16,18 @@ module Devise
 
       # validate is the password used in the past
       def password_archive_included?
-        unless deny_old_passwords.is_a? Fixnum
-          if deny_old_passwords.is_a? TrueClass and archive_count > 0
-            self.deny_old_passwords = archive_count
+        max_passwords = deny_old_passwords
+        
+        unless max_passwords.is_a? Fixnum
+          if max_passwords.is_a? TrueClass and archive_count > 0
+            max_passwords = archive_count
           else
-            self.deny_old_passwords = 0
+            max_passwords = 0
           end
         end
 
-        if self.class.deny_old_passwords > 0 and not self.password.nil?
-          old_passwords_including_cur_change = self.old_passwords.order(:id).reverse_order.limit(self.class.deny_old_passwords).to_a
+        if max_passwords > 0 and not self.password.nil?
+          old_passwords_including_cur_change = self.old_passwords.order(:id).reverse_order.limit(max_passwords).to_a
           old_passwords_including_cur_change << OldPassword.new(old_password_params)  # include most recent change in list, but don't save it yet!
           old_passwords_including_cur_change.each do |old_password|
             dummy                    = self.class.new
@@ -44,10 +46,6 @@ module Devise
 
       def deny_old_passwords
         self.class.deny_old_passwords
-      end
-
-      def deny_old_passwords=(count)
-        self.class.deny_old_passwords = count
       end
 
       def archive_count


### PR DESCRIPTION
Global settings shouldn't change based on doing something with a model instance. Also be consistent in the variable referenced for maximum old passwords because that method may be overridden in the model.