### PR TITLE
Do not use deprecated Fixnum class

### DIFF
--- a/lib/devise_security_extension/models/password_archivable.rb
+++ b/lib/devise_security_extension/models/password_archivable.rb
@@ -16,7 +16,7 @@ module Devise
 
       # validate is the password used in the past
       def password_archive_included?
-        unless deny_old_passwords.is_a? Fixnum
+        unless deny_old_passwords.is_a? Integer
           if deny_old_passwords.is_a? TrueClass and archive_count > 0
             self.deny_old_passwords = archive_count
           else

--- a/lib/devise_security_extension/models/password_expirable.rb
+++ b/lib/devise_security_extension/models/password_expirable.rb
@@ -13,7 +13,7 @@ module Devise
 
       # is an password change required?
       def need_change_password?
-        if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
+        if self.expire_password_after.is_a? Numeric
           self.password_changed_at.nil? or self.password_changed_at < self.expire_password_after.seconds.ago
         else
           false
@@ -22,7 +22,7 @@ module Devise
 
       # set a fake datetime so a password change is needed and save the record
       def need_change_password!
-        if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
+        if self.expire_password_after.is_a? Numeric
           need_change_password
           self.save(:validate => false)
         end
@@ -30,7 +30,7 @@ module Devise
 
       # set a fake datetime so a password change is needed
       def need_change_password
-        if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
+        if self.expire_password_after.is_a? Numeric
           self.password_changed_at = self.expire_password_after.seconds.ago
         end
 


### PR DESCRIPTION
In order to bring this project up to speed with Ruby 2.4 and Rails 5.x, I have replaced `Fixnum` with `Integer` and `Fixnum || Float` with `Numeric`.