### PR TITLE
handle password confirmation mismatched

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,7 @@
 de:
   errors:
     messages:
+      password_confirmation_mismatched: "nicht übereinstimmend."
       taken_in_past: "wurde bereits in der Vergangenheit verwendet!"
       equal_to_current_password: "darf nicht dem aktuellen Passwort entsprechen!"
       password_format: "müssen große, kleine Buchstaben und Ziffern enthalten"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   errors:
     messages:
+      password_confirmation_mismatched: "mismatched."
       taken_in_past: "was used previously."
       equal_to_current_password: "must be different than the current password."
       password_format: "must contain big, small letters and digits"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,7 @@
 es:
   errors:
     messages:
+      password_confirmation_mismatched: "no coinciden."
       taken_in_past: "la contraseña fue usada previamente, favor elegir otra."
       equal_to_current_password: "tiene que ser diferente a la contraseña actual."
       password_format: "tiene que contener mayúsculas, minúsculas y digitos "

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,7 @@
 it:
   errors:
     messages:
+      password_confirmation_mismatched: "non corrispondenti."
       taken_in_past: "e' stata gia' utilizzata in passato!"
       equal_to_current_password: " deve essere differente dalla password corrente!"
   devise:

--- a/lib/devise_security_extension/models/database_authenticatable_patch.rb
+++ b/lib/devise_security_extension/models/database_authenticatable_patch.rb
@@ -7,14 +7,21 @@ module Devise
         new_password = params[:password]
         new_password_confirmation = params[:password_confirmation]
 
-        result = if valid_password?(current_password) && new_password.present? && new_password_confirmation.present?
+        result = if valid_password?(current_password) && new_password.present? && new_password_confirmation.present? && new_password_confirmation == new_password
           update_attributes(params, *options)
         else
           self.assign_attributes(params, *options)
           self.valid?
           self.errors.add(:current_password, current_password.blank? ? :blank : :invalid)
           self.errors.add(:password, new_password.blank? ? :blank : :invalid)
-          self.errors.add(:password_confirmation, new_password_confirmation.blank? ? :blank : :invalid)
+          new_password_confirmation_error = if new_password_confirmation.blank?
+                                              :blank
+                                            elsif new_password != new_password_confirmation
+                                              I18n.t('errors.messages.password_confirmation_mismatched')
+                                            else
+                                              :invalid
+                                            end
+          self.errors.add(:password_confirmation, new_password_confirmation_error)
           false
         end
 


### PR DESCRIPTION
It checks if the new_password is equal to new_password_confirmation and gives out a proper error message if mismatched. 